### PR TITLE
Fix a bug in the sandbox breakout fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,12 +131,13 @@ module.exports = function (ast, vars) {
                 oldVars[element] = vars[element];
             })
 
-            node.params.forEach(function(key) {
+            for(var i=0; i<node.params.length; i++){
+                var key = node.params[i];
                 if(key.type == 'Identifier'){
                   vars[key.name] = null;
                 }
                 else return FAIL;
-            });
+            }
             for(var i in bodies){
                 if(walk(bodies[i]) === FAIL){
                     return FAIL;


### PR DESCRIPTION
The `return FAIL` was making the anonymous function of the forEach call
to return. That wasn't what I was expecting, so the last fix didn't have
any effects. I changed the code so now the `return FAIL` makes the main
function return.

This time I tested the fix, and it is working properly.