### PR TITLE
Short circuit evaluation

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,7 +80,6 @@ module.exports = function (ast, vars) {
             if (op === '|') return l | r;
             if (op === '&') return l & r;
             if (op === '^') return l ^ r;
-            if (op === '||') return l || r;
             
             return FAIL;
         }

--- a/index.js
+++ b/index.js
@@ -50,6 +50,14 @@ module.exports = function (ast, vars) {
                 if (r === FAIL) return FAIL;
                 return r;
             }
+            else if (op === '||') {
+                var l = walk(node.left);
+                if (l === FAIL) return FAIL;
+                if (l) return l;
+                var r = walk(node.right);
+                if (r === FAIL) return FAIL;
+                return r;
+            }
 
             var l = walk(node.left);
             if (l === FAIL) return FAIL;

--- a/index.js
+++ b/index.js
@@ -40,12 +40,22 @@ module.exports = function (ast, vars) {
         }
         else if (node.type === 'BinaryExpression' ||
                  node.type === 'LogicalExpression') {
+            var op = node.operator;
+
+            if (op === '&&') {
+                var l = walk(node.left);
+                if (l === FAIL) return FAIL;
+                if (!l) return l;
+                var r = walk(node.right);
+                if (r === FAIL) return FAIL;
+                return r;
+            }
+
             var l = walk(node.left);
             if (l === FAIL) return FAIL;
             var r = walk(node.right);
             if (r === FAIL) return FAIL;
             
-            var op = node.operator;
             if (op === '==') return l == r;
             if (op === '===') return l === r;
             if (op === '!=') return l != r;
@@ -62,7 +72,6 @@ module.exports = function (ast, vars) {
             if (op === '|') return l | r;
             if (op === '&') return l & r;
             if (op === '^') return l ^ r;
-            if (op === '&&') return l && r;
             if (op === '||') return l || r;
             
             return FAIL;

--- a/test/eval.js
+++ b/test/eval.js
@@ -122,7 +122,7 @@ test('constructor at runtime only', function(t) {
     t.equal(res, undefined);
 });
 
-test('short circuit evaluation', function(t) {
+test('short circuit evaluation AND', function(t) {
     t.plan(1);
 
     var variables = {
@@ -132,4 +132,18 @@ test('short circuit evaluation', function(t) {
     var ast = parse(src).body[0].expression;
     var res = evaluate(ast, variables);
     t.equals(res, null);
+})
+
+test('short circuit evaluation OR', function(t) {
+    t.plan(1);
+
+    var fnInvoked = false;
+    var variables = {
+        value: true,
+        fn: function() { fnInvoked = true}
+    };
+    var src = 'value || fn()';
+    var ast = parse(src).body[0].expression;
+    evaluate(ast, variables);
+    t.equals(fnInvoked, false);
 })

--- a/test/eval.js
+++ b/test/eval.js
@@ -121,3 +121,15 @@ test('constructor at runtime only', function(t) {
     var res = evaluate(ast);
     t.equal(res, undefined);
 });
+
+test('short circuit evaluation', function(t) {
+    t.plan(1);
+
+    var variables = {
+        value: null
+    };
+    var src = 'value && value.func()';
+    var ast = parse(src).body[0].expression;
+    var res = evaluate(ast, variables);
+    t.equals(res, null);
+})


### PR DESCRIPTION
Allow BinaryExpression to handle short-circuit evaluation.  This is needed for many use cases involving potentially-null values.

Example:
```
    var variables = {
        value: null
    };
    var src = 'value && value.length';
    var ast = parse(src).body[0].expression;
    var res = evaluate(ast, variables);
```

In javascript, the `value` will be a falsey, so js does not try to evaluate `value.length`.  However, currently BinaryExpression tries to evaluate both sides of the expression before performing the operation.  This leads to a crash, as length cannot be retrieved from a null value.
The result is the common javascript idiom `foo && access(foo)` will not work in static-eval

The fix is to evaluate the left side first, and only evaluate the right side if the left side is not falsey.