### PR TITLE
Fix the exception when get property from function's parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,8 @@
 var unparse = require('escodegen').generate;
 
+// flag of function argument
+var FUNCTION_ARGUMENT_FLAG = 'FUNCTION_ARGUMENT_FLAG';
+
 module.exports = function (ast, vars, opts) {
     if(!opts) opts = {};
     var rejectAccessToMethodsOnFunctions = !opts.allowAccessToMethodsOnFunctions;
@@ -129,6 +132,10 @@ module.exports = function (ast, vars, opts) {
             }
             if (node.property.type === 'Identifier' && !node.computed) {
                 if (isUnsafeProperty(node.property.name)) return FAIL;
+                // don't execute when object or property are argument
+                if(noExecute && (obj === FUNCTION_ARGUMENT_FLAG || node.property.name === FUNCTION_ARGUMENT_FLAG)){
+                    return FUNCTION_ARGUMENT_FLAG
+                }
                 return obj[node.property.name];
             }
             var prop = walk(node.property, noExecute);
@@ -161,7 +168,7 @@ module.exports = function (ast, vars, opts) {
             for(var i=0; i<node.params.length; i++){
                 var key = node.params[i];
                 if(key.type == 'Identifier'){
-                  vars[key.name] = null;
+                  vars[key.name] = FUNCTION_ARGUMENT_FLAG;
                 }
                 else return FAIL;
             }

--- a/test/eval.js
+++ b/test/eval.js
@@ -130,7 +130,7 @@ test('constructor at runtime only', function(t) {
     var res = evaluate(ast);
     t.equal(res, undefined);
 
-    var src = '(function(prop) { return {}[prop ? "benign" : "constructor"][prop] })("constructor")("alert(1)")()'
+    var src = '(function(prop) { return {}[prop !== "constructor" ? "benign" : "constructor"] })("constructor")("alert(1)")()'
     var ast = parse(src).body[0].expression;
     var res = evaluate(ast);
     t.equal(res, undefined);
@@ -175,3 +175,17 @@ test('function declaration does not invoke CallExpressions', function(t) {
     evaluate(ast, variables);
     t.equal(invoked, false);
 });
+
+test('MemberExpressions of function argument', function(t) {
+    t.plan(2);
+
+    var variables = {
+        values: [{a:{b:1}}, {a:{b:2}}, {a:{b:3}}],
+        receiver: []
+    };
+    var src = 'values.forEach(function(x) { receiver.push(x.a.b); })'
+    var ast = parse(src).body[0].expression;
+    evaluate(ast, variables);
+    t.equal(variables.receiver.length, 3);
+    t.deepEqual(variables.receiver, [1, 2, 3]);
+})


### PR DESCRIPTION
This MR resolve exception as below:
`
values.map(function(item){ return item.x})
`

This MR change function's parameter's initial value to a flag, so that we can skip execution of parameter's member expression during function declaration.